### PR TITLE
Hide dock badge when unread mail count is 0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,14 @@ const editInNewTabRe = 'https://mail.google.com/mail/.*#cmid%253D[0-9]+';
 // Set os specific stuff
 electron.ipcMain.on('update-dock', function(event, arg) {
   if (os.platform() === 'darwin') {
-    app.dock.setBadge(arg.toString());
+
+    if (arg > 0){
+      // Hide dock badge when unread mail count is 0
+      app.dock.setBadge(arg.toString());
+    }else{
+      app.dock.setBadge('');
+    }
+
   }
 });
 


### PR DESCRIPTION
it was really annoying when you see the dock badge is exist but there's no unread email
