### PR TITLE
Change to make windows compatible

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,1 +1,0 @@
-./node_modules/.bin/electron .

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "bin": { "gmail": "./launch.sh" },
   "scripts": {
-    "start": "./launch.sh",
+    "start": "electron .",
     "build": "electron-packager . Gmail --platform=darwin --arch=x64 --version=0.35.1 --icon=lib/media/gmail.png",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Windows doesn't know what to do with sh files but it does know what electron is (Assuming you have electron installed to begin with.) So this should make it with all Operating systems that electron supports.
